### PR TITLE
Remove dependency on deasync, wait on end instead.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "sinon": "^1.12.1"
   },
   "dependencies": {
-    "request-json": "^0.5.5",
-    "deasync": "^0.1.4"
+    "request-json": "^0.5.5"
   }
 }


### PR DESCRIPTION
For #7, removes the dependency on deasync to prevent intermittent crashes in appveyor environment.  The solution is a bit kludgy as it simply tightloops for 10 seconds on end if there are any pending tests, but is more reliable.  Eventually for #1 we will batch reporting and could possibly find a more clever way of handling this.