### PR TITLE
[#9] Wait until all tests sent before exiting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - 4
+  - 7
 
 script: npm test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ### Mocha reporter for AppVeyor
 
-Report your test to AppVeyor's testing infrastructure.
+Report your test results to AppVeyor's testing infrastructure.
 
-[![Build status](https://ci.appveyor.com/api/projects/status/ddacjc9dr7w2iqfw/branch/master?svg=true)](https://ci.appveyor.com/project/tolbertam/mocha-appveyor-reporter/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/ddacjc9dr7w2iqfw/branch/master?svg=true)](https://ci.appveyor.com/project/tolbertam/mocha-appveyor-reporter/branch/master) [![Build Status](https://travis-ci.org/tolbertam/mocha-appveyor-reporter.svg?branch=master)](https://travis-ci.org/tolbertam/mocha-appveyor-reporter)
+
+See it [in action](https://ci.appveyor.com/project/tolbertam/mocha-appveyor-reporter/build/tests) with this repository.
 
 ### Install
 
@@ -16,4 +18,22 @@ npm install --save-dev mocha-appveyor-reporter
 mocha --reporter mocha-appveyor-reporter
 ```
 
-See it [in action](https://ci.appveyor.com/project/tolbertam/mocha-appveyor-reporter/build/tests) with this repository
+#### Options
+
+This reporter is configurable via use of `--reporter-options` or by setting environment variables.
+
+|Reporter Option          |Environment Variable             |Default                                                  |
+|-------------------------|---------------------------------|---------------------------------------------------------|
+|appveyorBatchSize        |APPVEYOR\_BATCH\_SIZE            |100                                                      |
+|appveyorBatchIntervalInMs|APPVEYOR\_BATCH\_INTERVAL\_IN\_MS|1000                                                     |
+|appveyorApiUrl           |APPVEYOR\_API\_URL               |unset, but AppVeyor sets the environment variable for you|
+
+The reporter will by default batch and send tests in an API call to AppVeyor for every 100 tests completed or 1000ms
+elapsed (whichever happens first).
+
+To override this behavior you may do the following:
+
+```
+mocha --reporter mocha-appveyor-reporter --reporter-options appveyorBatchSize=1
+```
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-appveyor-reporter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Mocha Reporter to report tests while running in AppVeyor CI",
   "main": "mocha-appveyor-reporter.js",
   "scripts": {
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/tolbertam/mocha-appveyor-reporter",
   "devDependencies": {
     "chai": "^1.10.0",
-    "mocha": "^2.0.1",
+    "mocha": "^2.1.0",
     "mockery": "^1.4.0",
     "sinon": "^1.12.1"
   },

--- a/test/mocha-appveyor-reporter.tests.js
+++ b/test/mocha-appveyor-reporter.tests.js
@@ -5,7 +5,7 @@ reporter = require('../mocha-appveyor-reporter.js');
 require('chai').should();
 
 describe('mocha-appveyor-reporter', function() {
-  var tests = [], jsonPost;
+  var tests = [], jsonPost, apiUrl = 'http://localhost:9884/';
   before(function() {
     mockery.enable({
       warnOnUnregistered: false,
@@ -14,11 +14,12 @@ describe('mocha-appveyor-reporter', function() {
 
     mockery.registerMock('request-json', {
       createClient: function(url) {
-        url.should.equal(process.env.APPVEYOR_API_URL);
+        url.should.equal(apiUrl);
 
         jsonPost = sinon.spy(function(path, data, callback) {
-          path.should.equal('api/tests');
-          tests.push(data);
+          path.should.equal('api/tests/batch');
+          // concat tests as it will be an array of tests.
+          tests = tests.concat(data);
           callback(null);
         });
 
@@ -27,8 +28,6 @@ describe('mocha-appveyor-reporter', function() {
         }
       }
     });
-
-    process.env.APPVEYOR_API_URL = 'http://localhost:9884/'
   });
 
   after(function() {
@@ -40,7 +39,10 @@ describe('mocha-appveyor-reporter', function() {
 
     mocha = new Mocha({
       ui: 'bdd',
-      reporter: reporter
+      reporter: reporter,
+      reporterOptions: {
+        appveyorApiUrl: apiUrl
+      }
     });
   });
 


### PR DESCRIPTION
Motivation:

Previously there was a small possibility that some tests would not be
reported to AppVeyor before exiting.  Change to not exit until all tests
sent.

Modifications:

Mocha 2.1.0 introduces the capability of implementing a done(fn) on a
reporter that allows the reporter to finish any pending work before
exiting mocha.  Implemented this function on AppVeyorReporter.

Additionally, reintroduced logic that batches tests together.  Whenever
100ms elapses or 100 tests are enqueued, tests are sent to AppVeyor.

Set mocha requirement to 2.1.0+.

Bumped version to 0.3.0.

Result:

Mocha will not exit until tests are reported.

Added options appveyorApiUrl (APPVEYOR_API_URL), appveyorBatchSize
(100), and appveyorBatchIntervalInMs (APPVEYOR_BATCH_INTERVAL_IN_MS).